### PR TITLE
Allow asynchron usage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,7 +13,6 @@ exclude_lines =
     if __name__ == .__main__.:
     except ImportError:
 ignore_errors = True
-presicion = 1
 include = 
     *
     tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
   - "3.4"
   - "3.3"
-  - "3.2"
   - "2.7"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -83,6 +83,25 @@ CLOSE_PORT_AFTER_EACH_CALL = False
 MODE_RTU   = 'rtu'
 MODE_ASCII = 'ascii'
 
+# Generic command constants
+NUMBER_OF_BITS = 1
+NUMBER_OF_BYTES_FOR_ONE_BIT = 1
+NUMBER_OF_BYTES_BEFORE_REGISTERDATA = 1
+ALL_ALLOWED_FUNCTIONCODES = list(range(1, 7)) + [15, 16]  # To comply with both Python2 and Python3
+MAX_NUMBER_OF_REGISTERS = 255
+
+# Payload format constants, so datatypes can be told apart.
+# Note that bit datatype not is included, because it uses other functioncodes.
+PAYLOADFORMAT_LONG      = 'long'
+PAYLOADFORMAT_FLOAT     = 'float'
+PAYLOADFORMAT_STRING    = 'string'
+PAYLOADFORMAT_REGISTER  = 'register'
+PAYLOADFORMAT_REGISTERS = 'registers'
+
+ALL_PAYLOADFORMATS = [PAYLOADFORMAT_LONG, PAYLOADFORMAT_FLOAT, \
+                      PAYLOADFORMAT_STRING, PAYLOADFORMAT_REGISTER, \
+                      PAYLOADFORMAT_REGISTERS]
+
 ##############################
 ## Modbus instrument object ##
 ##############################
@@ -559,22 +578,6 @@ class Instrument():
             ValueError, TypeError, IOError
 
         """
-        NUMBER_OF_BITS = 1
-        NUMBER_OF_BYTES_FOR_ONE_BIT = 1
-        NUMBER_OF_BYTES_BEFORE_REGISTERDATA = 1
-        ALL_ALLOWED_FUNCTIONCODES = list(range(1, 7)) + [15, 16]  # To comply with both Python2 and Python3
-        MAX_NUMBER_OF_REGISTERS = 255
-
-        # Payload format constants, so datatypes can be told apart.
-        # Note that bit datatype not is included, because it uses other functioncodes.
-        PAYLOADFORMAT_LONG      = 'long'
-        PAYLOADFORMAT_FLOAT     = 'float'
-        PAYLOADFORMAT_STRING    = 'string'
-        PAYLOADFORMAT_REGISTER  = 'register'
-        PAYLOADFORMAT_REGISTERS = 'registers'
-
-        ALL_PAYLOADFORMATS = [PAYLOADFORMAT_LONG, PAYLOADFORMAT_FLOAT, \
-            PAYLOADFORMAT_STRING, PAYLOADFORMAT_REGISTER, PAYLOADFORMAT_REGISTERS]
 
         ## Check input values ##
         _checkFunctioncode(functioncode, ALL_ALLOWED_FUNCTIONCODES)  # Note: The calling facade functions should validate this

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -623,10 +623,12 @@ class Instrument():
         payloadFromSlave = _extractPayload(response, self.address, self.mode,
                                            functioncode)
 
-        return _checkResponse(functioncode, registeraddress, numberOfRegisters,
-                              numberOfRegisterBytes, numberOfDecimals, value,
-                              signed, payloadformat, payloadFromSlave)
+        _checkResponse(functioncode, registeraddress, numberOfRegisters,
+                       numberOfDecimals, value, signed, payloadFromSlave)
 
+        return _calculateReturn(functioncode, numberOfRegisters,
+                                numberOfDecimals, numberOfRegisterBytes, signed,
+                                payloadformat, payloadFromSlave)
 
     ##########################################
     ## Communication implementation details ##
@@ -930,9 +932,8 @@ def _buildPayloadToSlave(functioncode, registeraddress, numberOfRegisters,
 
 
 def _checkResponse(functioncode, registeraddress, numberOfRegisters,
-                   numberOfRegisterBytes, numberOfDecimals, value, signed,
-                   payloadformat, payloadFromSlave):
-    ## Check the contents in the response payload ##
+                   numberOfDecimals, value, signed, payloadFromSlave):
+
     if functioncode in [1, 2, 3, 4]:
         _checkResponseByteCount(payloadFromSlave)  # response byte count
 
@@ -952,7 +953,10 @@ def _checkResponse(functioncode, registeraddress, numberOfRegisters,
     if functioncode == 16:
         _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
 
-    ## Calculate return value ##
+
+def _calculateReturn(functioncode, numberOfRegisters, numberOfDecimals,
+                     numberOfRegisterBytes, signed, payloadformat, payloadFromSlave):
+
     if functioncode in [1, 2]:
         registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
         if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -663,10 +663,6 @@ class Instrument():
 
 
     def _communicate(self, request, number_of_bytes_to_read):
-        request = self._writeRequest(request, number_of_bytes_to_read)
-        return self._readResponse(request, number_of_bytes_to_read)
-
-    def _writeRequest(self, request, number_of_bytes_to_read):
         """Talk to the slave via a serial port.
 
         Args:
@@ -708,10 +704,12 @@ class Instrument():
 
         For Python3, the information sent to and from pySerial should be of the type bytes.
         This is taken care of automatically by MinimalModbus.
-
-
-
         """
+
+        request = self._writeRequest(request, number_of_bytes_to_read)
+        return self._readResponse(request, number_of_bytes_to_read)
+
+    def _writeRequest(self, request, number_of_bytes_to_read):
 
         _checkString(request, minlength=1, description='request')
         _checkInt(number_of_bytes_to_read)

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -663,6 +663,10 @@ class Instrument():
 
 
     def _communicate(self, request, number_of_bytes_to_read):
+        request = self._writeRequest(request, number_of_bytes_to_read)
+        return self._readResponse(request, number_of_bytes_to_read)
+
+    def _writeRequest(self, request, number_of_bytes_to_read):
         """Talk to the slave via a serial port.
 
         Args:
@@ -751,9 +755,13 @@ class Instrument():
             _print_out(text)
 
         # Write request
-        latest_write_time = time.time()
+        self._latest_write_time = time.time()
 
         self.serial.write(request)
+        return request
+
+
+    def _readResponse(self, request, number_of_bytes_to_read):
 
         # Read and discard local echo
         if self.handle_local_echo:
@@ -785,7 +793,7 @@ class Instrument():
                 answer,
                 _hexlify(answer),
                 len(answer),
-                (_LATEST_READ_TIMES.get(self.serial.port, 0) - latest_write_time) * _SECONDS_TO_MILLISECONDS,
+                (_LATEST_READ_TIMES.get(self.serial.port, 0) - self._latest_write_time) * _SECONDS_TO_MILLISECONDS,
                 self.serial.timeout * _SECONDS_TO_MILLISECONDS)
             _print_out(text)
 

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -646,16 +646,8 @@ class Instrument():
         # Build request
         request = _embedPayload(self.address, self.mode, functioncode, payloadToSlave)
 
-        _checkString(request, minlength=1, description='request')
-
-        if self.debug:
-            _print_out('\nMinimalModbus debug mode. Writing to instrument: {!r} ({})'. \
-                format(request, _hexlify(request)))
-
-        if sys.version_info[0] > 2:
-            request = bytes(request, encoding='latin1')  # Convert types to make it Python3 compatible
-
         return self._writeRequest(request)
+
 
     def _readCommandResponse(self, request, functioncode, payloadToSlave):
         DEFAULT_NUMBER_OF_BYTES_TO_READ = 1000
@@ -675,7 +667,7 @@ class Instrument():
         return self._readResponse(request, number_of_bytes_to_read)
 
 
-    def _communicate(self, request, number_of_bytes_to_read):
+    def _writeRequest(self, request):
         """Talk to the slave via a serial port.
 
         Args:
@@ -728,10 +720,6 @@ class Instrument():
         if sys.version_info[0] > 2:
             request = bytes(request, encoding='latin1')  # Convert types to make it Python3 compatible
 
-        request = self._writeRequest(request)
-        return self._readResponse(request, number_of_bytes_to_read)
-
-    def _writeRequest(self, request):
 
         if self.close_port_after_each_call:
             self.serial.open()

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -150,6 +150,9 @@ class Instrument():
         New in version 0.6.
         """
 
+        self.asynchron = False
+        """Set this to True if you do not want to read after writing a command. """
+
         self.debug = False
         """Set this to :const:`True` to print the communication details. Defaults to :const:`False`."""
 
@@ -608,6 +611,9 @@ class Instrument():
         request = self._writeCommandRequest(self.address,
                                             functioncode,
                                             payloadToSlave)
+
+        if self.asynchron:
+            return
 
         response = self._readCommandResponse(request,
                                              functioncode,

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -605,7 +605,8 @@ class Instrument():
                                               payloadformat)
 
         ## Communicate ##
-        response = self._performCommand(functioncode, payloadToSlave)
+        request = self._writeCommandRequest(functioncode, payloadToSlave)
+        response = self._readCommandResponse(request, functioncode, payloadToSlave)
 
         # Extract payload
         payloadFromSlave = _extractPayload(response, self.address, self.mode,
@@ -621,7 +622,7 @@ class Instrument():
     ##########################################
 
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _writeCommandRequest(self, functioncode, payloadToSlave):
         """Performs the command having the *functioncode*.
 
         Args:
@@ -639,10 +640,6 @@ class Instrument():
         response is done with the :func:`_extractPayload` function.
 
         """
-        request = self._writeCommandRequest(functioncode, payloadToSlave)
-        return self._readCommandResponse(request, functioncode, payloadToSlave)
-
-    def _writeCommandRequest(self, functioncode, payloadToSlave):
         _checkFunctioncode(functioncode, None)
         _checkString(payloadToSlave, description='payload')
 

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -576,6 +576,7 @@ class Instrument():
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
+            If asynchron is set this will alway return None.
 
         Raises:
             ValueError, TypeError, IOError
@@ -883,6 +884,32 @@ class Instrument():
 def _buildPayloadToSlave(functioncode, registeraddress, numberOfRegisters,
                          numberOfRegisterBytes, numberOfDecimals, value, signed,
                          payloadformat):
+    """Build the payload that will be send to the slave.
+
+    Args:
+        * functioncode (int): The function code for the command to be performed.
+          Can for example be 16 (Write register).
+        * registeraddress (int): The register address  (use decimal numbers, not
+          hex).
+        * numberOfRegisters (int): The number of registers to read/write. Only
+          certain values allowed, depends on payloadformat.
+        * numberOfRegisterBytes (int): The total number of bytes used. This is
+          calculated out of the number of Registes and the register with.
+        * numberOfDecimals (int): The number of decimals for content conversion.
+          Only for a single register.
+        * value (numerical or string or None or list of int): The value to store
+          in the register. Depends on payloadformat.
+        * signed (bol): Whether negative values should be accepted.
+        * payloadformat (None or string): None, 'long', 'float', 'string',
+          'register', 'registers'. Not necessary for single registers or bits.
+
+    Returns:
+        * payloadToSlave (str): The byte string that can be send to the slave.
+
+    Raises:
+        ValueError
+
+    """
 
     if functioncode in [1, 2]:
         payloadToSlave = _numToTwoByteString(registeraddress) + \
@@ -933,6 +960,28 @@ def _buildPayloadToSlave(functioncode, registeraddress, numberOfRegisters,
 
 def _checkResponse(functioncode, registeraddress, numberOfRegisters,
                    numberOfDecimals, value, signed, payloadFromSlave):
+    """Check if the data received by the slave is correct.
+
+    Args:
+        * functioncode (int): The function code for the command to be performed.
+          Can for example be 16 (Write register).
+        * registeraddress (int): The register address  (use decimal numbers, not
+          hex).
+        * numberOfRegisters (int): The number of registers to read/write. Only
+          certain values allowed, depends on payloadformat.
+        * numberOfDecimals (int): The number of decimals for content conversion.
+          Only for a single register.
+        * value (numerical or string or None or list of int): The value to store
+          in the register. Depends on payloadformat.
+        * signed (bol): Whether negative values should be accepted.
+        * payloadFromSlave (str): The byte string that was sent by the slave.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError, TypeError
+    """
 
     if functioncode in [1, 2, 3, 4]:
         _checkResponseByteCount(payloadFromSlave)  # response byte count
@@ -956,6 +1005,28 @@ def _checkResponse(functioncode, registeraddress, numberOfRegisters,
 
 def _calculateReturn(functioncode, numberOfRegisters, numberOfDecimals,
                      numberOfRegisterBytes, signed, payloadformat, payloadFromSlave):
+    """Calculate the value embedded in the payload received from the slave.
+
+    Args:
+        * functioncode (int): The function code for the command to be performed.
+          Can for example be 16 (Write register).
+        * numberOfRegisters (int): The number of registers to read/write. Only
+          certain values allowed, depends on payloadformat.
+        * numberOfDecimals (int): The number of decimals for content conversion.
+          Only for a single register.
+        * numberOfRegisterBytes (int): The total number of bytes used. This is
+          calculated out of the number of Registes and the register with.
+        * signed (bol): Whether negative values should be accepted.
+        * payloadformat (None or string): None, 'long', 'float', 'string',
+          'register', 'registers'. Not necessary for single registers or bits.
+        * payloadFromSlave (str): The byte string that was sent by the slave.
+
+    Returns:
+        The return value depending on the functioncode.
+
+    Raises:
+        ValueError
+    """
 
     if functioncode in [1, 2]:
         registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -605,8 +605,13 @@ class Instrument():
                                               payloadformat)
 
         ## Communicate ##
-        request = self._writeCommandRequest(functioncode, payloadToSlave)
-        response = self._readCommandResponse(request, functioncode, payloadToSlave)
+        request = self._writeCommandRequest(self.address,
+                                            functioncode,
+                                            payloadToSlave)
+
+        response = self._readCommandResponse(request,
+                                             functioncode,
+                                             payloadToSlave)
 
         # Extract payload
         payloadFromSlave = _extractPayload(response, self.address, self.mode,
@@ -622,10 +627,11 @@ class Instrument():
     ##########################################
 
 
-    def _writeCommandRequest(self, functioncode, payloadToSlave):
+    def _writeCommandRequest(self, slaveaddress, functioncode, payloadToSlave):
         """Performs the command having the *functioncode*.
 
         Args:
+            * slaveaddress (int): The address of the slave the data should be send to.
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
             * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
 
@@ -644,7 +650,10 @@ class Instrument():
         _checkString(payloadToSlave, description='payload')
 
         # Build request
-        request = _embedPayload(self.address, self.mode, functioncode, payloadToSlave)
+        request = _embedPayload(slaveaddress,
+                                self.mode,
+                                functioncode,
+                                payloadToSlave)
 
         return self._writeRequest(request)
 

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -143,7 +143,7 @@ class Instrument():
 
         New in version 0.5.
         """
-        
+
         self.handle_local_echo = False
         """Set to to :const:`True` if your RS-485 adaptor has local echo enabled. 
         Then the transmitted message will immeadiately appear at the receive line of the RS-485 adaptor.
@@ -841,8 +841,8 @@ class Instrument():
 
         For Python3, the information sent to and from pySerial should be of the type bytes.
         This is taken care of automatically by MinimalModbus.
-        
-        
+
+
 
         """
 
@@ -889,7 +889,7 @@ class Instrument():
 
         # Write request
         latest_write_time = time.time()
-        
+
         self.serial.write(request)
 
         # Read and discard local echo
@@ -1682,7 +1682,7 @@ def _hexencode(bytestring, insert_spaces = False):
     _checkString(bytestring, description='byte string')
 
     separator = '' if not insert_spaces else ' '
-    
+
     # Use plain string formatting instead of binhex.hexlify,
     # in order to have it Python 2.x and 3.x compatible
 
@@ -1735,9 +1735,9 @@ def _hexdecode(hexstring):
 
 def _hexlify(bytestring):
     """Convert a byte string to a hex encoded string, with spaces for easier reading.
-    
+
     This is just a facade for _hexencode() with insert_spaces = True.
-    
+
     See _hexencode() for details.
 
     """
@@ -1939,8 +1939,8 @@ _CRC16TABLE = (
     34177, 17728, 34561, 18368, 18048, 34369, 33281, 17088, 17280, 33601, 16640, 
     33217, 32897, 16448)
 """CRC-16 lookup table with 256 elements.
-    Built with this code:    
-    
+    Built with this code:
+
     poly=0xA001
     table = []
     for index in range(256):
@@ -1973,13 +1973,13 @@ def _calculateCrcString(inputstring):
 
     """
     _checkString(inputstring, description='input CRC string')
- 
+
     # Preload a 16-bit register with ones
     register = 0xFFFF
 
     for char in inputstring:
         register = (register >> 8) ^ _CRC16TABLE[(register ^ ord(char)) & 0xFF]
- 
+
     return _numToTwoByteString(register, LsbFirst=True)
 
 
@@ -2359,7 +2359,7 @@ def _print_out(inputstring):
 
 def _interpretRawMessage(inputstr):
     r"""Generate a human readable description of a Modbus bytestring.
-    
+
     Args:
         inputstr (str): The bytestring that should be interpreted.
 
@@ -2367,25 +2367,25 @@ def _interpretRawMessage(inputstr):
         A descriptive string.
 
     For example, the string ``'\n\x03\x10\x01\x00\x01\xd0q'`` should give something like::
-        
+
         TODO: update
-    
+
         Modbus bytestring decoder
         Input string (length 8 characters): '\n\x03\x10\x01\x00\x01\xd0q'
         Probably modbus RTU mode.
         Slave address: 10 (dec). Function code: 3 (dec).
         Valid message. Extracted payload: '\x10\x01\x00\x01'
 
-        Pos   Character Hex  Dec  Probable interpretation 
+        Pos   Character Hex  Dec  Probable interpretation
         -------------------------------------------------
-          0:  '\n'      0A    10  Slave address 
-          1:  '\x03'    03     3  Function code 
-          2:  '\x10'    10    16  Payload    
-          3:  '\x01'    01     1  Payload    
-          4:  '\x00'    00     0  Payload    
-          5:  '\x01'    01     1  Payload    
-          6:  '\xd0'    D0   208  Checksum, CRC LSB 
-          7:  'q'       71   113  Checksum, CRC MSB 
+          0:  '\n'      0A    10  Slave address
+          1:  '\x03'    03     3  Function code
+          2:  '\x10'    10    16  Payload
+          3:  '\x01'    01     1  Payload
+          4:  '\x00'    00     0  Payload
+          5:  '\x01'    01     1  Payload
+          6:  '\xd0'    D0   208  Checksum, CRC LSB
+          7:  'q'       71   113  Checksum, CRC MSB
 
     """
     raise NotImplementedError()
@@ -2437,23 +2437,23 @@ def _interpretRawMessage(inputstr):
             else:
                 description = 'Payload'
             output += '{0:3.0f}:  {1!r:<8}  {2:02X}  {2: 4.0f}  {3:<10} \n'.format(i, character, ord(character), description)
-        
+
     elif mode == MODE_ASCII:
         output += '\nPos   Character(s) Converted  Hex  Dec  Probable interpretation \n'
         output += '--------------------------------------------------------------- \n'
-        
+
         i = 0
         while i < len(inputstr):
-            
+
             if inputstr[i] in [':', '\r', '\n']:
-                if inputstr[i] == ':': 
+                if inputstr[i] == ':':
                     description = 'Start character'
                 else:
                     description = 'Stop character'
-                    
+
                 output += '{0:3.0f}:  {1!r:<8}                          {2} \n'.format(i, inputstr[i], description)
                 i += 1
-                
+
             else:
                 if i == 1:
                     description = 'Slave address'
@@ -2463,27 +2463,27 @@ def _interpretRawMessage(inputstr):
                     description = 'Checksum (LRC)'
                 else:
                     description = 'Payload'
-                
+
                 try:
                     hexvalue = _hexdecode(inputstr[i:i+2])
                     output +=  '{0:3.0f}:  {1!r:<8}     {2!r}     {3:02X}  {3: 4.0f}  {4} \n'.format(i, inputstr[i:i+2], hexvalue, ord(hexvalue), description)
                 except:
                     output +=  '{0:3.0f}:  {1!r:<8}     ?           ?     ?  {2} \n'.format(i, inputstr[i:i+2], description)
                 i += 2
-        
+
     # Generate description for the payload
     output += '\n\n'
     try:
         output += _interpretPayload(functioncode, extractedpayload)
     except:
         output += '\nCould not interpret the payload. \n\n' # Payload or function code not available
-    
+
     return output
-    
+
 
 def _interpretPayload(functioncode, payload):
     r"""Generate a human readable description of a Modbus payload.
-    
+
     Args:
       * functioncode (int): Function code
       * payload (str): The payload that should be interpreted. It should be a byte string.
@@ -2492,9 +2492,9 @@ def _interpretPayload(functioncode, payload):
         A descriptive string.
 
     For example, the payload ``'\x10\x01\x00\x01'`` for functioncode 3 should give something like::
-    
+
         TODO: Update
-    
+
 
     """
     raise NotImplementedError()
@@ -2502,7 +2502,7 @@ def _interpretPayload(functioncode, payload):
     output += 'Modbus payload decoder\n'
     output += 'Input payload (length {} characters): {!r} \n'.format(len(payload), payload)
     output += 'Function code: {} (dec).\n'.format(functioncode)
-    
+
     if len(payload) == 4:
         FourbyteMessageFirstHalfValue = _twoByteStringToNum(payload[0:2])
         FourbyteMessageSecondHalfValue = _twoByteStringToNum(payload[2:4])
@@ -2548,4 +2548,3 @@ def _getDiagnosticString():
     text += '\n'.join(sys.path) + '\n'
     text += '\n## End of diagnostic output ## \n'
     return text
-

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -586,70 +586,14 @@ class Instrument():
         _checkInt(numberOfRegisters, minvalue=1, maxvalue=MAX_NUMBER_OF_REGISTERS, description='number of registers')
         _checkBool(signed, description='signed')
 
-        if payloadformat is not None:
-            if payloadformat not in ALL_PAYLOADFORMATS:
-                raise ValueError('Wrong payload format variable. Given: {0!r}'.format(payloadformat))
-
-        ## Check combinations of input parameters ##
-        numberOfRegisterBytes = numberOfRegisters * _NUMBER_OF_BYTES_PER_REGISTER
-
-                    # Payload format
+        # Payload format
         if functioncode in [3, 4, 6, 16] and payloadformat is None:
             payloadformat = PAYLOADFORMAT_REGISTER
 
-        if functioncode in [3, 4, 6, 16]:
-            if payloadformat not in ALL_PAYLOADFORMATS:
-                raise ValueError('The payload format is unknown. Given format: {0!r}, functioncode: {1!r}.'.\
-                    format(payloadformat, functioncode))
-        else:
-            if payloadformat is not None:
-                raise ValueError('The payload format given is not allowed for this function code. ' + \
-                    'Given format: {0!r}, functioncode: {1!r}.'.format(payloadformat, functioncode))
+        _checkFormats(functioncode, payloadformat, numberOfRegisters, value, numberOfDecimals, signed)
 
-                    # Signed and numberOfDecimals
-        if signed:
-            if payloadformat not in [PAYLOADFORMAT_REGISTER, PAYLOADFORMAT_LONG]:
-                raise ValueError('The "signed" parameter can not be used for this data format. ' + \
-                    'Given format: {0!r}.'.format(payloadformat))
-
-        if numberOfDecimals > 0 and payloadformat != PAYLOADFORMAT_REGISTER:
-            raise ValueError('The "numberOfDecimals" parameter can not be used for this data format. ' + \
-                'Given format: {0!r}.'.format(payloadformat))
-
-                    # Number of registers
-        if functioncode not in [3, 4, 16] and numberOfRegisters != 1:
-            raise ValueError('The numberOfRegisters is not valid for this function code. ' + \
-                'NumberOfRegisters: {0!r}, functioncode {1}.'.format(numberOfRegisters, functioncode))
-
-        if functioncode == 16 and payloadformat == PAYLOADFORMAT_REGISTER and numberOfRegisters != 1:
-            raise ValueError('Wrong numberOfRegisters when writing to a ' + \
-                'single register. Given {0!r}.'.format(numberOfRegisters))
-            # Note: For function code 16 there is checking also in the content conversion functions.
-
-                    # Value
-        if functioncode in [5, 6, 15, 16] and value is None:
-            raise ValueError('The input value is not valid for this function code. ' + \
-                'Given {0!r} and {1}.'.format(value, functioncode))
-
-        if functioncode == 16 and payloadformat in [PAYLOADFORMAT_REGISTER, PAYLOADFORMAT_FLOAT, PAYLOADFORMAT_LONG]:
-            _checkNumerical(value, description='input value')
-
-        if functioncode == 6 and payloadformat == PAYLOADFORMAT_REGISTER:
-            _checkNumerical(value, description='input value')
-
-                    # Value for string
-        if functioncode == 16 and payloadformat == PAYLOADFORMAT_STRING:
-            _checkString(value, 'input string', minlength=1, maxlength=numberOfRegisterBytes)
-            # Note: The string might be padded later, so the length might be shorter than numberOfRegisterBytes.
-
-                    # Value for registers
-        if functioncode == 16 and payloadformat == PAYLOADFORMAT_REGISTERS:
-            if not isinstance(value, list):
-                raise TypeError('The value parameter must be a list. Given {0!r}.'.format(value))
-
-            if len(value) != numberOfRegisters:
-                raise ValueError('The list length does not match number of registers. ' + \
-                    'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
+        ## Check combinations of input parameters ##
+        numberOfRegisterBytes = numberOfRegisters * _NUMBER_OF_BYTES_PER_REGISTER
 
         ## Build payload to slave ##
         if functioncode in [1, 2]:
@@ -2018,6 +1962,67 @@ def _calculateLrcString(inputstring):
     lrcString = _numToOneByteString(lrc)
     return lrcString
 
+def _checkFormats(functioncode, payloadformat, numberOfRegisters, value, numberOfDecimals, signed):
+    if payloadformat is not None:
+        if payloadformat not in ALL_PAYLOADFORMATS:
+            raise ValueError('Wrong payload format variable. Given: {0!r}'.format(payloadformat))
+
+    ## Check combinations of input parameters ##
+    numberOfRegisterBytes = numberOfRegisters * _NUMBER_OF_BYTES_PER_REGISTER
+
+    if functioncode in [3, 4, 6, 16]:
+        if payloadformat not in ALL_PAYLOADFORMATS:
+            raise ValueError('The payload format is unknown. Given format: {0!r}, functioncode: {1!r}.'.\
+                format(payloadformat, functioncode))
+    else:
+        if payloadformat is not None:
+            raise ValueError('The payload format given is not allowed for this function code. ' + \
+                'Given format: {0!r}, functioncode: {1!r}.'.format(payloadformat, functioncode))
+
+                # Signed and numberOfDecimals
+    if signed:
+        if payloadformat not in [PAYLOADFORMAT_REGISTER, PAYLOADFORMAT_LONG]:
+            raise ValueError('The "signed" parameter can not be used for this data format. ' + \
+                'Given format: {0!r}.'.format(payloadformat))
+
+    if numberOfDecimals > 0 and payloadformat != PAYLOADFORMAT_REGISTER:
+        raise ValueError('The "numberOfDecimals" parameter can not be used for this data format. ' + \
+            'Given format: {0!r}.'.format(payloadformat))
+
+                # Number of registers
+    if functioncode not in [3, 4, 16] and numberOfRegisters != 1:
+        raise ValueError('The numberOfRegisters is not valid for this function code. ' + \
+            'NumberOfRegisters: {0!r}, functioncode {1}.'.format(numberOfRegisters, functioncode))
+
+    if functioncode == 16 and payloadformat == PAYLOADFORMAT_REGISTER and numberOfRegisters != 1:
+        raise ValueError('Wrong numberOfRegisters when writing to a ' + \
+            'single register. Given {0!r}.'.format(numberOfRegisters))
+        # Note: For function code 16 there is checking also in the content conversion functions.
+
+                # Value
+    if functioncode in [5, 6, 15, 16] and value is None:
+        raise ValueError('The input value is not valid for this function code. ' + \
+            'Given {0!r} and {1}.'.format(value, functioncode))
+
+    if functioncode == 16 and payloadformat in [PAYLOADFORMAT_REGISTER, PAYLOADFORMAT_FLOAT, PAYLOADFORMAT_LONG]:
+        _checkNumerical(value, description='input value')
+
+    if functioncode == 6 and payloadformat == PAYLOADFORMAT_REGISTER:
+        _checkNumerical(value, description='input value')
+
+                # Value for string
+    if functioncode == 16 and payloadformat == PAYLOADFORMAT_STRING:
+        _checkString(value, 'input string', minlength=1, maxlength=numberOfRegisterBytes)
+        # Note: The string might be padded later, so the length might be shorter than numberOfRegisterBytes.
+
+                # Value for registers
+    if functioncode == 16 and payloadformat == PAYLOADFORMAT_REGISTERS:
+        if not isinstance(value, list):
+            raise TypeError('The value parameter must be a list. Given {0!r}.'.format(value))
+
+        if len(value) != numberOfRegisters:
+            raise ValueError('The list length does not match number of registers. ' + \
+                'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
 def _checkMode(mode):
     """Check that the Modbus mode is valie.

--- a/minimalmodbus.py
+++ b/minimalmodbus.py
@@ -605,7 +605,11 @@ class Instrument():
                                               payloadformat)
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        response = self._performCommand(functioncode, payloadToSlave)
+
+        # Extract payload
+        payloadFromSlave = _extractPayload(response, self.address, self.mode,
+                                           functioncode)
 
         return _checkResponse(functioncode, registeraddress, numberOfRegisters,
                               numberOfRegisterBytes, numberOfDecimals, value,
@@ -655,11 +659,7 @@ class Instrument():
                     _print_out(template.format(self.mode, number_of_bytes_to_read, request))
 
         # Communicate
-        response = self._communicate(request, number_of_bytes_to_read)
-
-        # Extract payload
-        payloadFromSlave = _extractPayload(response, self.address, self.mode, functioncode)
-        return payloadFromSlave
+        return self._communicate(request, number_of_bytes_to_read)
 
 
     def _communicate(self, request, number_of_bytes_to_read):

--- a/tests/test_minimalmodbus.py
+++ b/tests/test_minimalmodbus.py
@@ -2054,26 +2054,44 @@ class TestDummyCommunication(ExtendedTestCase):
     ## Communicate ##
 
     def testCommunicateKnownResponse(self):
-        self.assertEqual( self.instrument._communicate('TESTMESSAGE', _LARGE_NUMBER_OF_BYTES), 'TESTRESPONSE' )
+        self.assertEqual(
+            self.instrument._readResponse(
+                self.instrument._writeRequest('TESTMESSAGE'),
+                _LARGE_NUMBER_OF_BYTES),
+            'TESTRESPONSE')
 
     def testCommunicateWrongType(self):
         for value in _NOT_STRINGS:
-            self.assertRaises(TypeError, self.instrument._communicate, value, _LARGE_NUMBER_OF_BYTES)
+            self.assertRaises(TypeError,
+                              self.instrument._writeRequest,
+                              value)
 
     def testCommunicateNoMessage(self):
-        self.assertRaises(ValueError, self.instrument._communicate, '', _LARGE_NUMBER_OF_BYTES)
+        self.assertRaises(ValueError,
+                          self.instrument._writeRequest,
+                          '')
 
     def testCommunicateNoResponse(self):
-        self.assertRaises(IOError, self.instrument._communicate, 'MessageForEmptyResponse', _LARGE_NUMBER_OF_BYTES)
+        self.assertRaises(IOError,
+                          self.instrument._readResponse,
+                          self.instrument._writeRequest('MessageForEmptyResponse'),
+                          _LARGE_NUMBER_OF_BYTES)
 
     def testCommunicateLocalEcho(self):
         self.instrument.handle_local_echo = True
-        self.assertEqual( self.instrument._communicate('TESTMESSAGE2', _LARGE_NUMBER_OF_BYTES), 'TESTRESPONSE2' )
+        self.assertEqual(
+            self.instrument._readResponse(
+                self.instrument._writeRequest('TESTMESSAGE2'),
+                _LARGE_NUMBER_OF_BYTES),
+            'TESTRESPONSE2')
 
     def testCommunicateWrongLocalEcho(self):
         self.instrument.handle_local_echo = True
-        self.assertRaises(IOError, self.instrument._communicate, 'TESTMESSAGE3', _LARGE_NUMBER_OF_BYTES)
-        
+        self.assertRaises(IOError,
+                          self.instrument._readResponse,
+                          self.instrument._writeRequest('TESTMESSAGE3'),
+                          _LARGE_NUMBER_OF_BYTES)
+
     ## __repr__ ##
 
     def testRepresentation(self):

--- a/tests/test_minimalmodbus.py
+++ b/tests/test_minimalmodbus.py
@@ -1965,65 +1965,90 @@ class TestDummyCommunication(ExtendedTestCase):
 
     def testPerformcommandKnownResponse(self):
         self.assertEqual(
-                minimalmodbus._extractPayload(
-                        self.instrument._performCommand(16, 'TESTCOMMAND'),
-                        self.instrument.address,
-                        self.instrument.mode,
-                        16), 'TRsp') # Total response length should be 8 bytes
+            minimalmodbus._extractPayload(
+                self.instrument._readCommandResponse(
+                    self.instrument._writeCommandRequest(16, 'TESTCOMMAND'),
+                    16, 'TESTCOMMAND'),
+                self.instrument.address,
+                self.instrument.mode, 16), 'TRsp') # Total response length should be 8 bytes
         self.assertEqual(
-                minimalmodbus._extractPayload(
-                        self.instrument._performCommand(75, 'TESTCOMMAND2'),
-                        self.instrument.address,
-                        self.instrument.mode,
-                        75), 'TESTCOMMANDRESPONSE2')
+            minimalmodbus._extractPayload(
+                self.instrument._readCommandResponse(
+                    self.instrument._writeCommandRequest(75, 'TESTCOMMAND2'),
+                    75, 'TESTCOMMAND2'),
+                self.instrument.address,
+                self.instrument.mode, 75), 'TESTCOMMANDRESPONSE2')
         self.assertEqual(
-                minimalmodbus._extractPayload(
-                        self.instrument._performCommand(2, '\x00\x3d\x00\x01'),
-                        self.instrument.address,
-                        self.instrument.mode,
-                        2), '\x01\x01')
+            minimalmodbus._extractPayload(
+                self.instrument._readCommandResponse(
+                    self.instrument._writeCommandRequest(2, '\x00\x3d\x00\x01'),
+                    2, '\x00\x3d\x00\x01'),
+                self.instrument.address,
+                self.instrument.mode, 2), '\x01\x01')
 
     def testPerformcommandWrongSlaveResponse(self):
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
-                          self.instrument._performCommand(1, 'TESTCOMMAND'),
+                          self.instrument._readCommandResponse(
+                              self.instrument._writeCommandRequest(1, 'TESTCOMMAND'),
+                              1, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           1) # Wrong slave address in response
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
-                          self.instrument._performCommand(2, 'TESTCOMMAND'),
+                          self.instrument._readCommandResponse(
+                              self.instrument._writeCommandRequest(2, 'TESTCOMMAND'),
+                              2, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           2) # Wrong function code in response
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
-                          self.instrument._performCommand(3, 'TESTCOMMAND'),
+                          self.instrument._readCommandResponse(
+                              self.instrument._writeCommandRequest(3, 'TESTCOMMAND'),
+                              3, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           3) # Wrong crc in response
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
-                          self.instrument._performCommand(4, 'TESTCOMMAND'),
+                          self.instrument._readCommandResponse(
+                              self.instrument._writeCommandRequest(4, 'TESTCOMMAND'),
+                              4, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           4) # Too short response message from slave
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
-                          self.instrument._performCommand(5, 'TESTCOMMAND'),
+                          self.instrument._readCommandResponse(
+                              self.instrument._writeCommandRequest(5, 'TESTCOMMAND'),
+                              5, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           5) # Error indication from slave
 
     def testPerformcommandWrongInputValue(self):
-        self.assertRaises(ValueError, self.instrument._performCommand, -1,  'TESTCOMMAND') # Wrong function code
-        self.assertRaises(ValueError, self.instrument._performCommand, 128, 'TESTCOMMAND')
+        self.assertRaises(ValueError,
+                          self.instrument._writeCommandRequest,
+                          -1,
+                          'TESTCOMMAND') # Wrong function code
+        self.assertRaises(ValueError,
+                          self.instrument._writeCommandRequest,
+                          128,
+                          'TESTCOMMAND')
 
     def testPerformcommandWrongInputType(self):
         for value in _NOT_INTERGERS:
-            self.assertRaises(TypeError, self.instrument._performCommand, value, 'TESTCOMMAND')
+            self.assertRaises(TypeError,
+                              self.instrument._writeCommandRequest,
+                              value,
+                              'TESTCOMMAND')
         for value in _NOT_STRINGS:
-            self.assertRaises(TypeError, self.instrument._performCommand, 16,     value)
+            self.assertRaises(TypeError,
+                              self.instrument._writeCommandRequest,
+                              16,
+                              value)
 
 
     ## Communicate ##
@@ -2155,7 +2180,7 @@ class TestDummyCommunicationDTB4824_RTU(ExtendedTestCase):
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
         self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 7) # port name, slave address (in decimal)
-    
+
     def testReadBit(self):
         self.assertEqual( self.instrument.read_bit(0x0800), 0) # LED AT
         self.assertEqual( self.instrument.read_bit(0x0801), 0) # LED Out1
@@ -2170,7 +2195,9 @@ class TestDummyCommunicationDTB4824_RTU(ExtendedTestCase):
     def testReadBits(self):
         self.assertEqual(
                 minimalmodbus._extractPayload(
-                        self.instrument._performCommand(2, '\x08\x10\x00\x09'),
+                        self.instrument._readCommandResponse(
+                            self.instrument._writeCommandRequest(2, '\x08\x10\x00\x09'),
+                            2, '\x08\x10\x00\x09'),
                         self.instrument.address,
                         self.instrument.mode,
                         2), '\x02\x07\x00')
@@ -2224,7 +2251,9 @@ class TestDummyCommunicationDTB4824_ASCII(ExtendedTestCase):
     def testReadBits(self):
         self.assertEqual(
                 minimalmodbus._extractPayload(
-                        self.instrument._performCommand(2, '\x08\x10\x00\x09'),
+                        self.instrument._readCommandResponse(
+                            self.instrument._writeCommandRequest(2, '\x08\x10\x00\x09'),
+                            2, '\x08\x10\x00\x09'),
                         self.instrument.address,
                         self.instrument.mode,
                         2), '\x02\x17\x00')

--- a/tests/test_minimalmodbus.py
+++ b/tests/test_minimalmodbus.py
@@ -1964,17 +1964,57 @@ class TestDummyCommunication(ExtendedTestCase):
     ## Perform command ##
 
     def testPerformcommandKnownResponse(self):
-        self.assertEqual( self.instrument._performCommand(16, 'TESTCOMMAND'), 'TRsp') # Total response length should be 8 bytes
-        self.assertEqual( self.instrument._performCommand(75, 'TESTCOMMAND2'), 'TESTCOMMANDRESPONSE2')
-        self.assertEqual( self.instrument._performCommand(2, '\x00\x3d\x00\x01'), '\x01\x01' ) # Read bit register 61 on slave 1 using function code 2.
+        self.assertEqual(
+                minimalmodbus._extractPayload(
+                        self.instrument._performCommand(16, 'TESTCOMMAND'),
+                        self.instrument.address,
+                        self.instrument.mode,
+                        16), 'TRsp') # Total response length should be 8 bytes
+        self.assertEqual(
+                minimalmodbus._extractPayload(
+                        self.instrument._performCommand(75, 'TESTCOMMAND2'),
+                        self.instrument.address,
+                        self.instrument.mode,
+                        75), 'TESTCOMMANDRESPONSE2')
+        self.assertEqual(
+                minimalmodbus._extractPayload(
+                        self.instrument._performCommand(2, '\x00\x3d\x00\x01'),
+                        self.instrument.address,
+                        self.instrument.mode,
+                        2), '\x01\x01')
 
     def testPerformcommandWrongSlaveResponse(self):
-        self.assertRaises(ValueError, self.instrument._performCommand, 1,  'TESTCOMMAND') # Wrong slave address in response
-        self.assertRaises(ValueError, self.instrument._performCommand, 2,  'TESTCOMMAND') # Wrong function code in response
-        self.assertRaises(ValueError, self.instrument._performCommand, 3,  'TESTCOMMAND') # Wrong crc in response
-        self.assertRaises(ValueError, self.instrument._performCommand, 4,  'TESTCOMMAND') # Too short response message from slave
-        self.assertRaises(ValueError, self.instrument._performCommand, 5,  'TESTCOMMAND') # Error indication from slave
-        
+        self.assertRaises(ValueError,
+                          minimalmodbus._extractPayload,
+                          self.instrument._performCommand(1, 'TESTCOMMAND'),
+                          self.instrument.address,
+                          self.instrument.mode,
+                          1) # Wrong slave address in response
+        self.assertRaises(ValueError,
+                          minimalmodbus._extractPayload,
+                          self.instrument._performCommand(2, 'TESTCOMMAND'),
+                          self.instrument.address,
+                          self.instrument.mode,
+                          2) # Wrong function code in response
+        self.assertRaises(ValueError,
+                          minimalmodbus._extractPayload,
+                          self.instrument._performCommand(3, 'TESTCOMMAND'),
+                          self.instrument.address,
+                          self.instrument.mode,
+                          3) # Wrong crc in response
+        self.assertRaises(ValueError,
+                          minimalmodbus._extractPayload,
+                          self.instrument._performCommand(4, 'TESTCOMMAND'),
+                          self.instrument.address,
+                          self.instrument.mode,
+                          4) # Too short response message from slave
+        self.assertRaises(ValueError,
+                          minimalmodbus._extractPayload,
+                          self.instrument._performCommand(5, 'TESTCOMMAND'),
+                          self.instrument.address,
+                          self.instrument.mode,
+                          5) # Error indication from slave
+
     def testPerformcommandWrongInputValue(self):
         self.assertRaises(ValueError, self.instrument._performCommand, -1,  'TESTCOMMAND') # Wrong function code
         self.assertRaises(ValueError, self.instrument._performCommand, 128, 'TESTCOMMAND')
@@ -2126,9 +2166,14 @@ class TestDummyCommunicationDTB4824_RTU(ExtendedTestCase):
         self.instrument.write_bit(0x0810, 1) # "Communication write in enabled".
         self.instrument.write_bit(0x0814, 0) # STOP
         self.instrument.write_bit(0x0814, 1) # RUN
-        
+
     def testReadBits(self):
-        self.assertEqual( self.instrument._performCommand(2, '\x08\x10\x00\x09'), '\x02\x07\x00') 
+        self.assertEqual(
+                minimalmodbus._extractPayload(
+                        self.instrument._performCommand(2, '\x08\x10\x00\x09'),
+                        self.instrument.address,
+                        self.instrument.mode,
+                        2), '\x02\x07\x00')
 
     def testReadRegister(self):
         self.assertEqual( self.instrument.read_register(0x1000), 64990) # Process value (PV)
@@ -2175,9 +2220,14 @@ class TestDummyCommunicationDTB4824_ASCII(ExtendedTestCase):
         self.instrument.write_bit(0x0810, 1) # "Communication write in enabled".
         self.instrument.write_bit(0x0814, 0) # STOP
         self.instrument.write_bit(0x0814, 1) # RUN
-        
+
     def testReadBits(self):
-        self.assertEqual( self.instrument._performCommand(2, '\x08\x10\x00\x09'), '\x02\x17\x00') 
+        self.assertEqual(
+                minimalmodbus._extractPayload(
+                        self.instrument._performCommand(2, '\x08\x10\x00\x09'),
+                        self.instrument.address,
+                        self.instrument.mode,
+                        2), '\x02\x17\x00')
 
     def testReadRegister(self):
         self.assertEqual( self.instrument.read_register(0x1000), 64990) # Process value (PV)

--- a/tests/test_minimalmodbus.py
+++ b/tests/test_minimalmodbus.py
@@ -1967,21 +1967,27 @@ class TestDummyCommunication(ExtendedTestCase):
         self.assertEqual(
             minimalmodbus._extractPayload(
                 self.instrument._readCommandResponse(
-                    self.instrument._writeCommandRequest(16, 'TESTCOMMAND'),
+                    self.instrument._writeCommandRequest(
+                        self.instrument.address,
+                        16, 'TESTCOMMAND'),
                     16, 'TESTCOMMAND'),
                 self.instrument.address,
                 self.instrument.mode, 16), 'TRsp') # Total response length should be 8 bytes
         self.assertEqual(
             minimalmodbus._extractPayload(
                 self.instrument._readCommandResponse(
-                    self.instrument._writeCommandRequest(75, 'TESTCOMMAND2'),
+                    self.instrument._writeCommandRequest(
+                        self.instrument.address,
+                        75, 'TESTCOMMAND2'),
                     75, 'TESTCOMMAND2'),
                 self.instrument.address,
                 self.instrument.mode, 75), 'TESTCOMMANDRESPONSE2')
         self.assertEqual(
             minimalmodbus._extractPayload(
                 self.instrument._readCommandResponse(
-                    self.instrument._writeCommandRequest(2, '\x00\x3d\x00\x01'),
+                    self.instrument._writeCommandRequest(
+                        self.instrument.address,
+                        2, '\x00\x3d\x00\x01'),
                     2, '\x00\x3d\x00\x01'),
                 self.instrument.address,
                 self.instrument.mode, 2), '\x01\x01')
@@ -1990,39 +1996,53 @@ class TestDummyCommunication(ExtendedTestCase):
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
                           self.instrument._readCommandResponse(
-                              self.instrument._writeCommandRequest(1, 'TESTCOMMAND'),
+                              self.instrument._writeCommandRequest(
+                                  self.instrument.address,
+                                  1, 'TESTCOMMAND'),
                               1, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           1) # Wrong slave address in response
+
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
                           self.instrument._readCommandResponse(
-                              self.instrument._writeCommandRequest(2, 'TESTCOMMAND'),
+                              self.instrument._writeCommandRequest(
+                                  self.instrument.address,
+                                  2, 'TESTCOMMAND'),
                               2, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           2) # Wrong function code in response
+
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
                           self.instrument._readCommandResponse(
-                              self.instrument._writeCommandRequest(3, 'TESTCOMMAND'),
+                              self.instrument._writeCommandRequest(
+                                  self.instrument.address,
+                                  3, 'TESTCOMMAND'),
                               3, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           3) # Wrong crc in response
+
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
                           self.instrument._readCommandResponse(
-                              self.instrument._writeCommandRequest(4, 'TESTCOMMAND'),
+                              self.instrument._writeCommandRequest(
+                                  self.instrument.address,
+                                  4, 'TESTCOMMAND'),
                               4, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
                           4) # Too short response message from slave
+
         self.assertRaises(ValueError,
                           minimalmodbus._extractPayload,
                           self.instrument._readCommandResponse(
-                              self.instrument._writeCommandRequest(5, 'TESTCOMMAND'),
+                              self.instrument._writeCommandRequest(
+                                  self.instrument.address,
+                                  5, 'TESTCOMMAND'),
                               5, 'TESTCOMMAND'),
                           self.instrument.address,
                           self.instrument.mode,
@@ -2031,10 +2051,12 @@ class TestDummyCommunication(ExtendedTestCase):
     def testPerformcommandWrongInputValue(self):
         self.assertRaises(ValueError,
                           self.instrument._writeCommandRequest,
+                          self.instrument.address,
                           -1,
                           'TESTCOMMAND') # Wrong function code
         self.assertRaises(ValueError,
                           self.instrument._writeCommandRequest,
+                          self.instrument.address,
                           128,
                           'TESTCOMMAND')
 
@@ -2042,11 +2064,13 @@ class TestDummyCommunication(ExtendedTestCase):
         for value in _NOT_INTERGERS:
             self.assertRaises(TypeError,
                               self.instrument._writeCommandRequest,
+                              self.instrument.address,
                               value,
                               'TESTCOMMAND')
         for value in _NOT_STRINGS:
             self.assertRaises(TypeError,
                               self.instrument._writeCommandRequest,
+                              self.instrument.address,
                               16,
                               value)
 
@@ -2214,7 +2238,9 @@ class TestDummyCommunicationDTB4824_RTU(ExtendedTestCase):
         self.assertEqual(
                 minimalmodbus._extractPayload(
                         self.instrument._readCommandResponse(
-                            self.instrument._writeCommandRequest(2, '\x08\x10\x00\x09'),
+                            self.instrument._writeCommandRequest(
+                                self.instrument.address,
+                                2, '\x08\x10\x00\x09'),
                             2, '\x08\x10\x00\x09'),
                         self.instrument.address,
                         self.instrument.mode,
@@ -2254,7 +2280,7 @@ class TestDummyCommunicationDTB4824_ASCII(ExtendedTestCase):
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
         self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 7, 'ascii') # port name, slave address (in decimal), mode
-    
+
     def testReadBit(self):
         self.assertEqual( self.instrument.read_bit(0x0800), 0) # LED AT
         self.assertEqual( self.instrument.read_bit(0x0801), 1) # LED Out1
@@ -2270,7 +2296,9 @@ class TestDummyCommunicationDTB4824_ASCII(ExtendedTestCase):
         self.assertEqual(
                 minimalmodbus._extractPayload(
                         self.instrument._readCommandResponse(
-                            self.instrument._writeCommandRequest(2, '\x08\x10\x00\x09'),
+                            self.instrument._writeCommandRequest(
+                                self.instrument.address,
+                                2, '\x08\x10\x00\x09'),
                             2, '\x08\x10\x00\x09'),
                         self.instrument.address,
                         self.instrument.mode,


### PR DESCRIPTION
This series of patches was created to be able to use minimalmodbus asynchronously without breaking the current interface. It was taking care of that tests are green at every commit.

When working asynchronous we do not want to wait for the data after sending the request. We will most of the time wait for a select to return later.

To make this work the write and read operations had to be separated up to the _genericCommand method.
If the switch asynchron is set the _genericCommand method will return after sending the request without waiting for the response.

When changing large methods I seized the moment to break them into hand able peaces. This sometime leads to many parameters moved around. In my opinion we should think about a shared object holding at least some of the data that is moved around frequently.

Example:
In my case I am now able to inherit from Instrument overwriting the constructor and setting my parameters as needed. Especially I am setting a transport object as serial.
 
On write I call the _genericCommand method and save the parameters.

In the data_received callback I call _extractPayload and _calculateReturn as normally used in _genericCommand when working  synchronously.