### PR TITLE
Doc: BYTEORDER_BIG_SWAP is "PDP endian"

### DIFF
--- a/docs/modbusdetails.rst
+++ b/docs/modbusdetails.rst
@@ -159,7 +159,7 @@ which byte order that is used.
 Name                  Description                  Use                    Example
 ===================== ============================ ====================== =======
 Big endian (Motorola) High order byte first        BYTEORDER_BIG          ABCD
-?                     Big endian with byte swap    BYTEORDER_BIG_SWAP     BADC
+PDP endian (PDP-11)   Big endian with byte swap    BYTEORDER_BIG_SWAP     BADC
 ?                     Little endian with byte swap BYTEORDER_LITTLE_SWAP  CDAB
 Little endian (Intel) Low order byte first         BYTEORDER_LITTLE       DCBA
 ===================== ============================ ====================== =======


### PR DESCRIPTION
Not that it really matters, but... it's a funny small tidbit of computer history. The perverse `BYTEORDER_BIG_SWAP` byte order has been used by at least the PDP-11 computer, and has since been known as “PDP-endian”.